### PR TITLE
Allow multiple emisscen

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog
 master
 ------
 
-- (`#238 <https://github.com/openscm/pymagicc/pull/238>`_) Add gotcha documentation for emissions files
+- (`#238 <https://github.com/openscm/pymagicc/pull/238>`_) Add documentation for handling of World region in emissions files
 - (`#303 <https://github.com/openscm/pymagicc/pull/303>`_) Refactor ``pymagicc.io`` into multiple files
 - (`#301 <https://github.com/openscm/pymagicc/pull/301>`_) Add MAGICC7 variables ``AEROSOL_RF``, ``HEAT_EARTH`` and ``HEAT_NONOCEAN``
 - (`#299 <https://github.com/openscm/pymagicc/pull/299>`_) Make conversion of FORTRAN safe units apply to ``.MAG`` files too and be more consistent

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog
 master
 ------
 
+- (`#238 <https://github.com/openscm/pymagicc/pull/238>`_) Add gotcha documentation for emissions files
 - (`#303 <https://github.com/openscm/pymagicc/pull/303>`_) Refactor ``pymagicc.io`` into multiple files
 - (`#301 <https://github.com/openscm/pymagicc/pull/301>`_) Add MAGICC7 variables ``AEROSOL_RF``, ``HEAT_EARTH`` and ``HEAT_NONOCEAN``
 - (`#299 <https://github.com/openscm/pymagicc/pull/299>`_) Make conversion of FORTRAN safe units apply to ``.MAG`` files too and be more consistent

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Changelog
 master
 ------
 
-- (`#238 <https://github.com/openscm/pymagicc/pull/238>`_) Add documentation for handling of World region in emissions files
+- (`#238 <https://github.com/openscm/pymagicc/pull/238>`_) Add documentation for handling of World region in ``.SCEN7`` files
 - (`#303 <https://github.com/openscm/pymagicc/pull/303>`_) Refactor ``pymagicc.io`` into multiple files
 - (`#301 <https://github.com/openscm/pymagicc/pull/301>`_) Add MAGICC7 variables ``AEROSOL_RF``, ``HEAT_EARTH`` and ``HEAT_NONOCEAN``
 - (`#299 <https://github.com/openscm/pymagicc/pull/299>`_) Make conversion of FORTRAN safe units apply to ``.MAG`` files too and be more consistent

--- a/docs/magicc_flags.rst
+++ b/docs/magicc_flags.rst
@@ -206,6 +206,10 @@ MAGICC6 there can only be ``SCEN`` files so this isn't an issue). All other
 that SCEN files don't contain easy to read metadata hence overwriting with them is
 difficult/dangerous.
 
+*Gotcha:* If the scenario file has a region mode other than World, all World region data are ignored.
+This means that all emissions cannot be *currently* stored in a single SCEN7 file as MHalo data is only
+provided as a single World region, while most other species are disaggregated by region.
+
 *Gotcha:* If you set ``FILE_EMISSCEN_X=NONE`` then MAGICC will just move on to the
 next ``FILE_EMISSCEN_X`` flag. However, from above it's clear that if you set
 ``FILE_TUNINGMODEL_X=NONE``, MAGICC will look for ``MAGTUNE_NONE.CFG``, not find it

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -150,13 +150,10 @@ def test_run_failure_confusing_emissions_scenarios(package, invalid_config):
         "Dataframe with Pymagicc and Pandas, then feed this single Dataframe into "
         "Pymagicc's run API."
     )
+    with pytest.raises(ValueError, match=error_msg):
+        package.run()
 
-    if package.version == 6:
-        with pytest.raises(ValueError, match=error_msg):
-            package.check_config()
-    else:
-        with pytest.warns(DeprecationWarning, match=error_msg):
-            package.check_config()
+    assert package.config is None
 
 
 @pytest.mark.parametrize(

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -150,10 +150,14 @@ def test_run_failure_confusing_emissions_scenarios(package, invalid_config):
         "Dataframe with Pymagicc and Pandas, then feed this single Dataframe into "
         "Pymagicc's run API."
     )
-    with pytest.raises(ValueError, match=error_msg):
-        package.run()
 
-    assert package.config is None
+    if package.version == 6:
+        with pytest.raises(ValueError, match=error_msg):
+            package.run()
+        assert package.config is None
+    else:
+        with pytest.warns(DeprecationWarning, match=error_msg):
+            package.run()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -153,11 +153,10 @@ def test_run_failure_confusing_emissions_scenarios(package, invalid_config):
 
     if package.version == 6:
         with pytest.raises(ValueError, match=error_msg):
-            package.run()
-        assert package.config is None
+            package.check_config()
     else:
         with pytest.warns(DeprecationWarning, match=error_msg):
-            package.run()
+            package.check_config()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
# Pull request

For MAGICC7 onwards warn use of multiple emisscen files using a DeprecationWarning. This provides a path to raising an exception in future

- [x] Tests added
- [x] Documentation added (where applicable)
- [x] Description in ``CHANGELOG.rst`` added

Implements 1. in #237 