### PR TITLE
Add citation cff file

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.1.0
 message: |
   If you make any use of MAGICC, its license requires citing of
 
-    M. Meinshausen, S. C. B. Raper and T. M. L. Wigley (2011). "Emulating coupled atmosphere-ocean and carbon cycle models with a simpler model, MAGICC6: Part I "Model Description and Calibration." Atmospheric Chemistry and Physics 11: 1417-1456. https://doi.org/10.5194/acp-11-1417-2011
+    M. Meinshausen, S. C. B. Raper and T. M. L. Wigley (2011). "Emulating coupled atmosphere-ocean and carbon cycle models with a simpler model, MAGICC6: Part 1 "Model Description and Calibration." Atmospheric Chemistry and Physics 11: 1417-1456. https://doi.org/10.5194/acp-11-1417-2011
 
   If you use Pymagicc in your research, please additionally cite
 
@@ -37,3 +37,30 @@ repository-code: https://github.com/openclimatedata/pymagicc
 license: other-open
 # Fallback URL as different licenses used for code and included binary
 license-url: https://github.com/openscm/pymagicc
+keywords:
+  - climate model
+  - climate science
+  - Python
+references:
+  - type: article
+    authors:
+      - family-names: Meinshausen
+        given-names: M.
+      - family-names: Raper
+        given-names: S. C. B.
+      - family-names: Wigley
+        given-names: T. M. L.
+    title: "Emulating coupled atmosphere-ocean and carbon cycle models with a simpler model, MAGICC6: Part 1: Model Description and Calibration"
+    date-published: 2011-02-16
+    doi: 10.5194/acp-11-1417-2011
+  - type: article
+    authors:
+      - family-names: Gieseke
+        given-names: R.
+      - family-names: Willner
+        given-names: S. N.
+      - family-names: Mengel
+        given-names: M.
+    title: "Pymagicc: A Python wrapper for the simple climate model MAGICC"
+    date-published: 2018-02-04
+    doi: 10.21105/joss.00516

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -51,6 +51,7 @@ references:
       - family-names: Wigley
         given-names: T. M. L.
     title: "Emulating coupled atmosphere-ocean and carbon cycle models with a simpler model, MAGICC6: Part 1: Model Description and Calibration"
+    journal: Atmospheric Chemistry and Physics
     date-published: 2011-02-16
     doi: 10.5194/acp-11-1417-2011
   - type: article
@@ -62,5 +63,6 @@ references:
       - family-names: Mengel
         given-names: M.
     title: "Pymagicc: A Python wrapper for the simple climate model MAGICC"
+    journal: Journal of Open Source Software
     date-published: 2018-02-04
     doi: 10.21105/joss.00516

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,39 @@
+cff-version: 1.1.0
+message: |
+  If you make any use of MAGICC, its license requires citing of
+
+    M. Meinshausen, S. C. B. Raper and T. M. L. Wigley (2011). "Emulating coupled atmosphere-ocean and carbon cycle models with a simpler model, MAGICC6: Part I "Model Description and Calibration." Atmospheric Chemistry and Physics 11: 1417-1456. https://doi.org/10.5194/acp-11-1417-2011
+
+  If you use Pymagicc in your research, please additionally cite
+
+    R. Gieseke, S. N. Willner and M. Mengel, (2018). Pymagicc: A Python wrapper for the simple climate model MAGICC. Journal of Open Source Software, 3(22), 516, https://doi.org/10.21105/joss.00516
+
+  For proper reproducibility please reference the version of Pymagicc used. In Python it can be printed with
+
+    import pymagicc
+    print(pymagicc.__version__)
+
+  Pymagicc releases are archived at Zenodo and the version used should also be cited. See https://doi.org/10.5281/zenodo.1111815
+title: Pymagicc - A Python wrapper for the reduced complexity climate model MAGICC
+doi: 10.5281/zenodo.1111815
+authors:
+  - given-names: Zeb
+    family-names: Nicholls
+    orcid: https://orcid.org/0000-0002-4767-2723
+  - given-names: Robert
+    family-names: Gieseke
+    orcid: https://orcid.org/0000-0002-1236-5109
+  - given-names: Jared
+    family-names: Lewis
+    orcid: https://orcid.org/0000-0002-8155-8924
+  - given-names: Sven
+    family-names: Willner
+    orcid: https://orcid.org/0000-0001-6798-6247
+  - given-names: Matthias
+    family-names: Mengel
+    orcid: https://orcid.org/0000-0001-6724-9685
+repository-code: https://github.com/openclimatedata/pymagicc
+# SPDX code
+license: other-open
+# Fallback URL as different licenses used for code and included binary
+license-url: https://github.com/openscm/pymagicc


### PR DESCRIPTION
With GitHub adding support for CITATION.cff files to display a citation info on the side (see e.g. https://github.com/IAMconsortium/pyam/) i though it might be worth adding one here too.

https://twitter.com/natfriedman/status/1420122675813441540

With Zenodo also using this for displaying info on their website when dong releases i'm not sure how all of this will render out.

https://twitter.com/zotero/status/1420515377390530560

I've copied the citation info from the Readme and added a link to the 'latest' DOI from Zenodo.

We also ought to create releases to trigger a Zenodo archival, not sure if some beta versions should also be archived as they might have been used in papers?

Full spec: https://github.com/citation-file-format/citation-file-format